### PR TITLE
Add screen and rsync to cam-pipeline-tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN apt-get update \
     make \
     curl \
     tar \
+    screen \
+    rsync \
     locales \
     && locale-gen "en_US.UTF-8"
 


### PR DESCRIPTION
This PR adds screen and rsync to cam-pipeline-tools, which can aid in running long-running jobs on this image in Kubernetes.