### PR TITLE
Add non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,5 +53,5 @@ RUN curl -O -L https://github.com/balhoff/ctd-to-owl/releases/download/v$CTD/ctd
 ENV PATH "/tools/ctd-to-owl-$CTD/bin:$PATH"
 
 ## Set USER to nru
-RUN useradd -M -u 1000 nru
+RUN useradd -m -u 1000 nru
 USER nru

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,3 +51,7 @@ RUN curl -O -L https://github.com/balhoff/ctd-to-owl/releases/download/v$CTD/ctd
     && tar -zxf ctd-to-owl-$CTD.tgz \
     && chmod +x /tools/ctd-to-owl-$CTD
 ENV PATH "/tools/ctd-to-owl-$CTD/bin:$PATH"
+
+## Set USER to nru
+RUN useradd -M -u 1000 nru
+USER nru


### PR DESCRIPTION
Sterling had been having some permission issues when trying to run cam-pipeline earlier this month. I'm not sure what caused it, but adding an nru (non-root user) and changing the permissions on the PVC so that /current and /success are both owned by this user seems to have fixed it. Also, running this job as a non-root user is better from a security perspective.