### PR TITLE
Reorganize Dockerfile and automatically set up package with GitHub action

### DIFF
--- a/.github/workflows/generate-docker-package.yaml
+++ b/.github/workflows/generate-docker-package.yaml
@@ -7,6 +7,7 @@
 name: 'Publish Docker image to Github Packages'
 
 on:
+  push:
   release:
     types: [published]
 

--- a/.github/workflows/generate-docker-package.yaml
+++ b/.github/workflows/generate-docker-package.yaml
@@ -1,0 +1,45 @@
+# This GitHub Action generates and publishes a Docker image of this repository
+# to the GitHub Packages repository. It is triggered when a new package is released.
+#
+# Based on the NameRes release.yaml file at
+# https://github.com/TranslatorSRI/NameResolution/blob/a4f72e3c283dcb40a7280b55650dae63c5625e82/.github/workflows/release.yml
+
+name: 'Publish Docker image to Github Packages'
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to GitHub Packages tagged with "latest" and version number.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images:
+            ghcr.io/${{ github.repository }}
+      - name: Login to ghcr
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push to GitHub Packages
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: BRANCH_NAME=${{ github.event.release.target_commitish }}

--- a/.github/workflows/generate-docker-package.yaml
+++ b/.github/workflows/generate-docker-package.yaml
@@ -7,7 +7,6 @@
 name: 'Publish Docker image to Github Packages'
 
 on:
-  push:
   release:
     types: [published]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,11 @@
+# Configuration options:
+# - ${USERNAME} is the name of the non-root user to create.
+ARG USERNAME=nru
+# - ${USERID} is the UID of the non-root user.
+ARG USERID=1001
+# - ${DATA} is where the writeable data volume should be mounted.
+ARG DATA=/data
+
 ### 1. Get Linux
 FROM monarchinitiative/ubergraph:1.1
 
@@ -56,4 +64,9 @@ ENV PATH "/tools/ctd-to-owl-$CTD/bin:$PATH"
 RUN curl -fLo scala-cli.deb https://github.com/Virtuslab/scala-cli/releases/latest/download/scala-cli-x86_64-pc-linux.deb \
     && dpkg -i scala-cli.deb
 
-RUN useradd --system --uid 1001 -m cam
+### 4. Set up the $DATA directory.
+mkdir -p $DATA
+
+### 5. Set up a non-root user.
+RUN useradd --uid ${USERID} -m ${USERNAME}
+RUN chown ${USERNAME} ${DATA}

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ARG MAT=0.1
 
 ENV LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8
 
-RUN apt-get update \
+RUN apt-get update && apt-get upgrade \
     && DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
     software-properties-common \
     build-essential \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends 
     make \
     curl \
     tar \
+    vim \
     screen \
     rsync \
     locales

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,12 @@
+### 1. Get Linux
+FROM monarchinitiative/ubergraph:1.1
+
+ARG ROBOT=1.9.3
+ARG JENA=4.7.0
+ARG BGR=1.7
+ARG CTD=0.3.0
+ARG MAT=0.1
+
 # Configuration options:
 # - ${USERNAME} is the name of the non-root user to create.
 ARG USERNAME=nru
@@ -8,20 +17,12 @@ ARG DATA=/data
 # - ${TOOLS} is where the writeable tools volume should be mounted.
 ARG TOOLS=/tools
 
-### 1. Get Linux
-FROM monarchinitiative/ubergraph:1.1
-
-ARG ROBOT=1.9.3
-ARG JENA=4.7.0
-ARG BGR=1.7
-ARG CTD=0.3.0
-ARG MAT=0.1
-
 ### 2. Get Java and all required system libraries
 ENV LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8
 
-RUN apt-get update && apt-get upgrade \
-    && DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
+RUN apt-get update
+RUN DEBIAN_FRONTEND="noninteractive" apt-get upgrade -y --no-install-recommends
+RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
     software-properties-common \
     build-essential \
     openjdk-11-jdk-headless \
@@ -31,21 +32,22 @@ RUN apt-get update && apt-get upgrade \
     tar \
     screen \
     rsync \
-    locales \
-    && locale-gen "en_US.UTF-8"
+    locales
+RUN locale-gen "en_US.UTF-8"
 
 ###### SCALA-CLI ######
 RUN curl -fLo scala-cli.deb https://github.com/Virtuslab/scala-cli/releases/latest/download/scala-cli-x86_64-pc-linux.deb \
     && dpkg -i scala-cli.deb
 
 ### 3. Set up the $DATA and $TOOLS directory.
-RUN mkdir -p $DATA
-RUN mkdir -p $TOOLS
+RUN mkdir -p ${DATA}
+RUN mkdir -p ${TOOLS}
 
 ### 4. Set up a non-root user.
 RUN useradd --uid ${USERID} -m ${USERNAME}
 RUN chown ${USERNAME} ${DATA}
 RUN chown ${USERNAME} ${TOOLS}
+USER ${USERNAME}
 
 ### 5. Install custom tools
 WORKDIR $TOOLS

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ ARG USERNAME=nru
 ARG USERID=1001
 # - ${DATA} is where the writeable data volume should be mounted.
 ARG DATA=/data
+# - ${TOOLS} is where the writeable tools volume should be mounted.
+ARG TOOLS=/tools
 
 ### 1. Get Linux
 FROM monarchinitiative/ubergraph:1.1
@@ -16,7 +18,6 @@ ARG CTD=0.3.0
 ARG MAT=0.1
 
 ### 2. Get Java and all required system libraries
-
 ENV LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8
 
 RUN apt-get update && apt-get upgrade \
@@ -33,40 +34,45 @@ RUN apt-get update && apt-get upgrade \
     locales \
     && locale-gen "en_US.UTF-8"
 
+###### SCALA-CLI ######
+RUN curl -fLo scala-cli.deb https://github.com/Virtuslab/scala-cli/releases/latest/download/scala-cli-x86_64-pc-linux.deb \
+    && dpkg -i scala-cli.deb
 
-### 3. Install custom tools
-WORKDIR /tools
+### 3. Set up the $DATA and $TOOLS directory.
+RUN mkdir -p $DATA
+RUN mkdir -p $TOOLS
+
+### 4. Set up a non-root user.
+RUN useradd --uid ${USERID} -m ${USERNAME}
+RUN chown ${USERNAME} ${DATA}
+RUN chown ${USERNAME} ${TOOLS}
+
+### 5. Install custom tools
+WORKDIR $TOOLS
 
 ###### JENA ######
 RUN curl -O -L http://archive.apache.org/dist/jena/binaries/apache-jena-$JENA.tar.gz \
     && tar -zxf apache-jena-$JENA.tar.gz
-ENV PATH "/tools/apache-jena-$JENA/bin:$PATH"
+ENV PATH "$TOOLS/apache-jena-$JENA/bin:$PATH"
 
 ###### BLAZEGRAPH-RUNNER ######
 RUN curl -O -L https://github.com/balhoff/blazegraph-runner/releases/download/v$BGR/blazegraph-runner-$BGR.tgz \
     && tar -zxf blazegraph-runner-$BGR.tgz \
     && chmod +x /tools/blazegraph-runner-$BGR
-ENV PATH "/tools/blazegraph-runner-$BGR/bin:$PATH"
+ENV PATH "$TOOLS/blazegraph-runner-$BGR/bin:$PATH"
 
 ###### MATERIALIZER ######
 RUN curl -O -L https://github.com/balhoff/materializer/releases/download/v$MAT/materializer-$MAT.tgz \
     && tar -zxf materializer-$MAT.tgz \
     && chmod +x /tools/materializer-$MAT
-ENV PATH "/tools/materializer-$MAT/bin:$PATH"
+ENV PATH "$TOOLS/materializer-$MAT/bin:$PATH"
 
 ###### CTD-TO-OWL ######
 RUN curl -O -L https://github.com/balhoff/ctd-to-owl/releases/download/v$CTD/ctd-to-owl-$CTD.tgz \
     && tar -zxf ctd-to-owl-$CTD.tgz \
     && chmod +x /tools/ctd-to-owl-$CTD
-ENV PATH "/tools/ctd-to-owl-$CTD/bin:$PATH"
+ENV PATH "$TOOLS/ctd-to-owl-$CTD/bin:$PATH"
 
-###### SCALA-CLI ######
-RUN curl -fLo scala-cli.deb https://github.com/Virtuslab/scala-cli/releases/latest/download/scala-cli-x86_64-pc-linux.deb \
-    && dpkg -i scala-cli.deb
+### 6. Start in the $DATA directory.
+WORKDIR $DATA
 
-### 4. Set up the $DATA directory.
-mkdir -p $DATA
-
-### 5. Set up a non-root user.
-RUN useradd --uid ${USERID} -m ${USERNAME}
-RUN chown ${USERNAME} ${DATA}


### PR DESCRIPTION
This PR reorganizes the Dockerfile so that tools are in `/tools` and data is in `/data`, as well as an `nru` user (non-root user) that can be used to run this package. All of these options are configurable. It also adds a GitHub Action to automatically regenerate the Docker package whenever we make a new release.

Closes #9.